### PR TITLE
passed missing args to DBresult call in timecourseTable

### DIFF
--- a/R/timecourseTable.R
+++ b/R/timecourseTable.R
@@ -130,6 +130,8 @@ timecourseTable <- function(object, value = "expression", lib.norm = TRUE,
     }
     DBtmpfilter <- DBresult(object, contrasts = contrasts,
                             p.adjust = p, result.type = "list",
+                            abs.fold = abs.fold,
+                            pvalue.threshold = pvalue.threshold,
                             top.sig = TRUE)
     feature.filter <- c()
     for (i in DBtmpfilter) {

--- a/tests/testthat/test_TCseq.R
+++ b/tests/testthat/test_TCseq.R
@@ -66,3 +66,35 @@ peaks_expect2 <- data.frame(chr = c(rep("chr1",3),rep("chr2", 2), rep("chr3",2))
 
 expect_equal(merged_peaks2, peaks_expect2)
 
+test_that("timecourseTable filters by abs.fold", {
+  # loading data
+  data(tca_ATAC)
+  tca <- DBanalysis(tca_ATAC)
+  
+  # using default values
+  res1 <- DBresult(tca,
+                   contrasts = colnames(tca@contrasts),
+                   result.type = 'list',
+                   top.sig = TRUE)
+  n_deg1 <- length(unique(na.omit(unlist(lapply(res1, function(x) x$id[(x$paj < .05) && (abs(x$logFC) > 2)])))))
+  
+  tca1 <- timecourseTable(tca,
+                          filter = TRUE)
+  
+  expect_equal(nrow(tcTable(tca1)), n_deg1)
+  
+  # change defaults
+  res2 <- DBresult(tca,
+                   contrasts = colnames(tca@contrasts),
+                   result.type = 'list',
+                   abs.fold = 5,
+                   top.sig = TRUE)
+  
+  n_deg2 <- length(unique(na.omit(unlist(lapply(res2, function(x) x$id[(x$paj < .05) && (abs(x$logFC) > 5)])))))
+  
+  tca2 <- timecourseTable(tca,
+                          abs.fold = 5,
+                          filter = TRUE)
+  
+  expect_equal(nrow(tcTable(tca2)), n_deg2)
+})


### PR DESCRIPTION
Related  #1

`timecourseTable` doesn't filter the output as expected when changing the default values of `abs.fold` or `pvalue.threshold` and `filter = TRUE`.

``` r
# loading libraries
library(TCseq)

# loading data
data(tca_ATAC)
tca <- DBanalysis(tca_ATAC)

# using default values
res1 <- DBresult(tca,
                contrasts = colnames(tca@contrasts),
                result.type = 'list',
                top.sig = TRUE)
n_deg <- length(unique(unlist(lapply(res1, function(x) x$id[x$paj < .05 && (abs(x$logFC) > 2)]))))

tca1 <- timecourseTable(tca,
                        filter = TRUE)

nrow(tcTable(tca1)) == n_deg
#> [1] TRUE

# change defaults
res2 <- DBresult(tca,
                 contrasts = colnames(tca@contrasts),
                 result.type = 'list',
                 abs.fold = 5,
                 top.sig = TRUE)

n_deg <- length(unique(na.omit(unlist(lapply(res2, function(x) x$id[(x$paj < .05) && (abs(x$logFC) > 5)])))))

tca2 <- timecourseTable(tca,
                        abs.fold = 5,
                        filter = TRUE)

nrow(tcTable(tca2)) == n_deg
#> [1] FALSE
```

<sup>Created on 2019-04-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
 
The problem seems to be that the `abs.fold` and `pvalue.threshold` are not passed to the `DBresult()` call within `timecourseTable`. I made a minor change and added a test case to fix the issue.